### PR TITLE
fix for additional returns on persist

### DIFF
--- a/src/editable-div/editable-div.tsx
+++ b/src/editable-div/editable-div.tsx
@@ -13,6 +13,7 @@ const Wrap = styled.div`
 
 const Text = styled.div`
     outline: none;
+    display: inline-block;
     width: 100%;
     white-space: pre-wrap;
     word-break: break-word;
@@ -37,16 +38,26 @@ const EditableDiv = ({
     const noteStart = React.useRef(null)
     const editableDiv = React.useRef(null)
 
+    const resetFocus = () => {
+        noteStart.current.focus()
+    }
+
+    React.useEffect(()=>{
+        const handler = (event) => {
+            if (event.target !== editableDiv.current) {
+                resetFocus()
+            }
+        }
+        document.addEventListener('click', handler)
+        return () => document.removeEventListener('click', handler)
+    },[])
+
     const persistEdit = () => {
         const newContent = editableDiv.current.innerText
         setEditing(false)
         if (newContent !== content) {
-            setContent(id, editableDiv.current.innerText)
+            setContent(id, newContent)
         }
-    }
-
-    const resetFocus = () => {
-        noteStart.current.focus()
     }
 
     const handleBlur = e => {
@@ -75,6 +86,7 @@ const EditableDiv = ({
                 onFocus={e => setEditing(true)}
                 onBlur={handleBlur}
                 onKeyDown={handleKeyDown}
+                onKeyUp={()=>console.log(editableDiv.current.innerHTML)}
                 suppressContentEditableWarning={true}
             >
             {editing

--- a/src/user-bar/user-bar.tsx
+++ b/src/user-bar/user-bar.tsx
@@ -19,8 +19,8 @@ const LogoutButton = styled.button`
     border-radius: 3px;
     border: none;
     cursor: pointer;
-    padding-top: 3px;
-    padding-bottom: 3px;
+    margin-left: 4px;
+    padding: 4px;
     transition: color 80ms, background-color 80ms;
     color: ${({theme}) => theme.black};
     background-color: ${({theme}) => rgba(theme.primary, 0)}; 


### PR DESCRIPTION
turns out if `editableContent` is applied to a block level element it tries to add divs for returns, bu uses `br` when you have multiple, then `.innerText` resolves it as an extra linebreak. Swapping to `inline-block` fixes that, but results in it being impossible (apparently?) to click off the editable div to change focus, so had to add the event listener to force the focus change when a click occurs 