### PR TITLE
prevent editable div fighting for focus

### DIFF
--- a/src/editable-div/editable-div.tsx
+++ b/src/editable-div/editable-div.tsx
@@ -43,6 +43,9 @@ const EditableDiv = ({
     }
 
     React.useEffect(()=>{
+        if (!editing){
+            return
+        }
         const handler = (event) => {
             if (event.target !== editableDiv.current) {
                 resetFocus()
@@ -50,7 +53,7 @@ const EditableDiv = ({
         }
         document.addEventListener('click', handler)
         return () => document.removeEventListener('click', handler)
-    },[])
+    },[editing])
 
     const persistEdit = () => {
         const newContent = editableDiv.current.innerText


### PR DESCRIPTION
noticed after the focus changes the EditableDiv constantly fights for focus, this prevents the listener from being attached while not in an editing state